### PR TITLE
Updating playbooks to install RabbitMQ

### DIFF
--- a/Ansible/hosts.ini
+++ b/Ansible/hosts.ini
@@ -3,8 +3,11 @@ localhost
 [aspproducers]
 localhost
 
-[rabbitmqconsumers]
+[elkservers]
 localhost
 
-[elkmachines]
+[rabbitmqservers]
+localhost
+
+[rabbitmqconsumers]
 localhost

--- a/Ansible/playbooks/hello-world.yw
+++ b/Ansible/playbooks/hello-world.yw
@@ -1,5 +1,5 @@
 ---
-- hosts: aspproducers:rabbitmqconsumers:elkmachines
+- hosts: aspproducers:elkservers:rabbitmqconsumers:rabbitmqservers
   become: yes
   become_method: sudo
   tasks:

--- a/Ansible/playbooks/rabbitmq-installation.yw
+++ b/Ansible/playbooks/rabbitmq-installation.yw
@@ -1,0 +1,57 @@
+---
+- hosts: aspproducers:rabbitmqconsumers:rabbitmqservers
+  become: true
+  become_method: sudo
+
+  tasks:       
+  - name: Update all packages
+    apt:
+      name: "*"
+      state: latest
+      update_cache: yes
+      force_apt_get: true
+      
+  - name: Verify if python-software-properties replacement is installed
+    apt: pkg=software-properties-common state=present
+    
+  - name: Install RabbitMQ public key
+    apt_key:
+      url: https://dl.bintray.com/rabbitmq/Keys/rabbitmq-release-signing-key.asc
+      state: present
+
+  - name: Add RabbitMQ official repo
+    apt_repository:
+      repo: deb https://dl.bintray.com/rabbitmq/debian bionic main
+      state: present
+      filename: rabbitmq-server
+   
+  - name: Install Erlang public key
+    apt_key:
+      url: http://binaries.erlang-solutions.com/debian/erlang_solutions.asc
+      state: present
+
+  - name: Add Erlang offical repo
+    apt_repository:
+      repo: deb http://binaries.erlang-solutions.com/debian bionic contrib
+      state: present
+      filename: erlang
+
+  - name: Install RabbitMQ package
+    apt:
+      name: "{{ item }}"
+      update_cache: yes
+      install_recommends: yes
+      state: present
+    with_items:
+      - rabbitmq-server
+
+  - name: Enable RabbitMQ plugins
+    rabbitmq_plugin:
+      names: rabbitmq_management
+      state: enabled
+    notify:
+      - restart rabbitmq
+
+  handlers:
+  - name: restart rabbitmq
+    service: name=rabbitmq-server state=restarted


### PR DESCRIPTION
Created new host name to include rabbitMQ servers and rabbitMQ producers separately.
Included new playbook based on http://virtualelephant.com/2018/06/16/ansible-rabbitmq-playbooks/